### PR TITLE
Next prerelease version should be patch increment

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -48,7 +48,11 @@ runs:
         if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
           echo "::set-output name=value::${GITHUB_REF#refs/tags/v}"
         else
-          echo "::set-output name=value::${PREV#v}~$(git rev-parse --short HEAD)"
+          IFS=. read major minor patch <<< "${PREV}"
+          IFS="~" read patch prerelease <<< "${patch}"
+          (( patch++ ))
+          NEXT="${major}.${minor}.${patch}"
+          echo "::set-output name=value::${NEXT#v}~$(git rev-parse --short HEAD)"
         fi
 
     - name: Build deb


### PR DESCRIPTION
Per [FTR 027](https://lindenlab.atlassian.net/wiki/spaces/SLPP/pages/2611740680/FTR+027+Ingredient+Release+Workflow#Choose-a-version), the next prerelease version should increment the patch version number. The current implementation keeps the latest version and appends a hash.

We could also consider using https://github.com/WyriHaximus/github-action-next-semvers.

A nice to have would be to increment the correct portion of the semver version based on PR labels as described [here](https://lindenlab.atlassian.net/wiki/spaces/SLT/pages/2587394049/Automatic+Release+Notes).