### PR TITLE
Translate - in git semantic version tags to ~ in package versions

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -46,10 +46,20 @@ runs:
         PREV: ${{ steps.previous-tag.outputs.tag }}
       run: |
         if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
-          echo "value=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+          tag_version="${GITHUB_REF#refs/tags/v}"
         else
-          echo "value=${PREV#v}~$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          # Add an abbreviated commit to the version to indicate this is a
+          # "prerelease" of the previous tag... which really it isn't, it's a
+          # prerelease of the next release. If the identified previous tag
+          # already has a prerelease portion (`-` in a semantic version), this
+          # *will* get two prerelease sections, but that's OK.
+          tag_version="${PREV#v}~$(git rev-parse --short HEAD)"
         fi
+        # The git tag is a semantic version, where `-` indicates a prerelease
+        # version. Debian & RPM packages use `~` to indicate prerelease
+        # versions. So translate `-`s into `~`s.
+        tag_version="${tag_version//-/\~}"
+        echo "value=$tag_version" >> $GITHUB_OUTPUT
 
     - name: Build deb
       shell: bash


### PR DESCRIPTION
In some cases we might wanna explicitly tag a commit with a prerelease version. If we consider those tags to be semantic versions, we [would indicate prereleaseness with `-`](https://semver.org/#spec-item-9). Let's translate a `-` in a git version tag to a `~` in the `VERSION` we provide nfpm, so that a tag such as `v23.6.26-3` will indicate the version `23.6.26~3` to nfpm. This make sense?