### PR TITLE
Add `tag-prefix` input to support alternate tag schemes

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -22,6 +22,9 @@ inputs:
   setup-nfpm:
     description: Whether to set up nfpm
     default: true
+  tag-prefix:
+    description: Prefix that identifies a tag as a version tag
+    default: v
 
 runs:
   using: composite
@@ -38,22 +41,24 @@ runs:
       id: previous-tag
       with:
         fallback: ${{ inputs.fallback-version }}
+        prefix: ${{ inputs.tag-prefix }}
 
     - name: Determine next version
       id: version
       shell: bash
       env:
         PREV: ${{ steps.previous-tag.outputs.tag }}
+        TAG_PREFIX: ${{ inputs.tag-prefix }}
       run: |
-        if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
-          tag_version="${GITHUB_REF#refs/tags/v}"
+        if [[ "$GITHUB_REF" == refs/tags/"$TAG_PREFIX"* ]]; then
+          tag_version="${GITHUB_REF#refs/tags/"$TAG_PREFIX"}"
         else
           # Add an abbreviated commit to the version to indicate this is a
           # "prerelease" of the previous tag... which really it isn't, it's a
           # prerelease of the next release. If the identified previous tag
           # already has a prerelease portion (`-` in a semantic version), this
           # *will* get two prerelease sections, but that's OK.
-          tag_version="${PREV#v}~$(git rev-parse --short HEAD)"
+          tag_version="${PREV#"$TAG_PREFIX"}~$(git rev-parse --short HEAD)"
         fi
         # The git tag is a semantic version, where `-` indicates a prerelease
         # version. Debian & RPM packages use `~` to indicate prerelease


### PR DESCRIPTION
Howdy. This change adds a `tag-prefix` input that we can use to specify which tags to use as version tags. Repositories that make multiple build products can then prefix tags differently to mark commits on certain branches as the versions of certain products (when some of the products are built with nfpm, anyway).

For instance, a project with `main` and `lts/main` lines of development could namespace the release tags on the `lts/main` branch, so that version tags with the same numbers could coexist in the same repository (as, say, `v1.2.3` and `lts/v1.2.3`):

```yaml
name: Build LTS

on:
  pull_request:
  push:
    tags: [lts/v*]

jobs:
  build-lts:
    steps:
      - uses: secondlife/action-nfpm@v2
        with:
          fallback-version: 0.1.0
          tag-prefix: lts/v
      # ...
```

We can find the most recent tag with the intended prefix using the `prefix` input to github-action-get-previous-tag, new in [v1.3.0](https://github.com/WyriHaximus/github-action-get-previous-tag/releases/tag/v1.3.0), which is now available in the referenced secondlife-3p fork.